### PR TITLE
(refactor/socket) - configure all serverSocket listeners in the same place 

### DIFF
--- a/client/src/pageArena/codeContainer.jsx
+++ b/client/src/pageArena/codeContainer.jsx
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
-import { setCode, requestCodeCheck, receiveCodeCheck, getCompUpdate} from '../actions/actions.js';
-import {socketSubmitSoln, socketCompUpdate} from '../socketHandler.js';
+import { setCode, requestCodeCheck } from '../actions/actions.js';
+import { socketEmitSubmission } from '../socketHandler.js';
 import Editor from './editor.jsx';
 
 const mapStateToProps = (state) => {
@@ -19,18 +19,9 @@ const mapDispatchToProps = (dispatch) => {
     submitCode: function(params) {
       // dispatch requestCodeCheck to set state: isFetching to true
       dispatch(requestCodeCheck());
-
-      // dispatch receiveCodeCheck to set state: isFetching to false, status to result from socket conn
-      socketSubmitSoln(params.room, params.problemId, params.user, params.code, function(result) {
-        dispatch(receiveCodeCheck(result));
-      });
+      // emmit submission event to server
+      socketEmitSubmission(params.room, params.problemId, params.user, params.code);
     },
-    getLiveUpdate: function(params) {
-      // dispatch getCompUpdate to set state: compUpdate to update from socket conn
-      socketCompUpdate(params.room, function(update) {
-        dispatch(getCompUpdate(update));
-      });
-    }
 
   }
 }

--- a/client/src/pageArena/editor.jsx
+++ b/client/src/pageArena/editor.jsx
@@ -35,15 +35,6 @@ class Editor extends React.Component {
     super(props);
   };
 
-  // setup listener for 'compUpdate'
-  componentDidMount() {
-    var params = {
-      room: this.props.room.name,
-    }
-
-    this.props.getLiveUpdate(params);
-  };
-
   render() {
     return (
       <div>

--- a/client/src/pageDashboard/chatroom.jsx
+++ b/client/src/pageDashboard/chatroom.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Axios from 'axios';
 import { Link } from 'react-router';
-import { socketGetProblem, socketSendChatMsg } from '../socketHandler.js';
+import { socketEmitProblem, socketEmitMsg } from '../socketHandler.js';
 
 class Chatroom extends React.Component {
   constructor(props) {
@@ -17,9 +17,10 @@ class Chatroom extends React.Component {
   }
 
   handleMessageSend() {
-    // sends message to redux
     const context = this;
-    socketSendChatMsg(this.props.room.name, (this.props.user.username || 'Tester') + ': ' + this.state.message);
+    // emit 'message' event to server
+    socketEmitMsg(this.props.room.name, this.props.user.username, this.state.message);
+
     // updates current message to blank after message is sent
     this.setState({
       message: ''
@@ -42,9 +43,8 @@ class Chatroom extends React.Component {
   handleReadyButton() {
     const context = this;
     const room = this.props.room;
-    socketGetProblem(room.name, room.problemId, (problem) => {
-      context.props.setProblem(problem);
-    });
+    // emit 'problem' event to server
+    socketEmitProblem(room.name, room.problemId);
   }
 
   componentDidMount() {

--- a/client/src/pageDashboard/chatroomContainer.jsx
+++ b/client/src/pageDashboard/chatroomContainer.jsx
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { updateMessages, setProblem } from '../actions/actions.js';
+// import { updateMessages, setProblem } from '../actions/actions.js';
 import Chatroom from './chatroom.jsx';
 
 const mapStateToProps = (state) => {
@@ -10,20 +10,20 @@ const mapStateToProps = (state) => {
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    updateMessages: function(message) {
-      dispatch(updateMessages(message));
-    },
-    setProblem: function(problem) {
-      dispatch(setProblem(problem));
-    }
-  }
-}
+// const mapDispatchToProps = (dispatch) => {
+//   return {
+//     updateMessages: function(message) {
+//       dispatch(updateMessages(message));
+//     },
+//     setProblem: function(problem) {
+//       dispatch(setProblem(problem));
+//     }
+//   }
+// }
 
 const ChatroomContainer = connect(
   mapStateToProps,
-  mapDispatchToProps
+  // mapDispatchToProps
 )(Chatroom);
 
 export default ChatroomContainer;

--- a/client/src/pageDashboard/roomContainer.jsx
+++ b/client/src/pageDashboard/roomContainer.jsx
@@ -1,5 +1,12 @@
 import { connect } from 'react-redux';
-import { setRoom, updateMessages } from '../actions/actions.js';
+import  {
+          setRoom,
+          updateMessages,     // used with socketOnMsg
+          setProblem,         // used with socketOnProblem
+          receiveCodeCheck,   // used with socketOnSubmission
+          getCompUpdate       // used with socketOnUpdate
+        } from '../actions/actions.js';
+
 import RoomEntry from './roomEntry.jsx';
 
 const mapStateToProps = (state, ownProps) => {
@@ -12,12 +19,21 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    updateMessages: function(message) {
-      dispatch(updateMessages(message));
-    },
-    updateCurrentRoom: function(room) {
+    setRoom: function(room) {
       dispatch(setRoom(room));
-    }
+    },
+    updateMessages: function(serverMessage) {
+      dispatch(updateMessages(serverMessage));
+    },
+    setProblem: function(problem) {
+      dispatch(setProblem(problem));
+    },
+    receiveCodeCheck: function(result) {
+      dispatch(receiveCodeCheck(result));
+    },
+    getCompUpdate: function(update) {
+      dispatch(getCompUpdate(update));
+    },
   }
 }
 

--- a/client/src/pageDashboard/roomEntry.jsx
+++ b/client/src/pageDashboard/roomEntry.jsx
@@ -1,19 +1,38 @@
 import React from 'react';
-import { socketJoinRoom, socketClosePrevRoom } from '../socketHandler.js';
+import {
+          socketClosePrevRoom,
+          socketEmitJoin,
+          socketOnMsg,
+          socketOnProblem,
+          socketOnSubmission,
+          socketOnUpdate
+        } from '../socketHandler.js';
+
 
 const RoomEntry = (props) => {
 
   const joinClickHandler = () => {
-      // close clientSocket connection for previous room
+      // close clientSocket connection for previously selected room
       socketClosePrevRoom(props.currRoom);
+      // emit join event
+      socketEmitJoin(props.room.name, props.username);
 
-      // open clientSocket connection for selected room
-      socketJoinRoom(props.room.name, props.username || 'Tester', (serverMessage) => {
-        props.updateMessages(serverMessage);
+      // configure all clientSocketListeners to Redux through action function
+      socketOnMsg(props.room.name, (serverMessage) => {
+        props.updateMessages(serverMessage);  //action
+      });
+      socketOnProblem(props.room.name, (problem) => {
+        props.setProblem(problem);            //action
+      });
+      socketOnSubmission(props.room.name, (result) => {
+        props.receiveCodeCheck(result);       //action
+      });
+      socketOnUpdate(props.room.name, (update) => {
+        props.getCompUpdate(update);          //action
       });
 
       // update currtent room using redux
-      props.updateCurrentRoom(props.room);
+      props.setRoom(props.room);
   };
 
   return (

--- a/server/resources/roomController.js
+++ b/server/resources/roomController.js
@@ -49,7 +49,7 @@ exports.joinRoom = function(req, res) {
       }
       console.log("inside "+roomID+" room count is ", count);
 
-      // configure socketHandeler
+      // configure socketHandler
       socketHandler.handleJoin(socket, roomID, playerInSession);
       socketHandler.handleLeave(socket, roomID, playerInSession);
       socketHandler.handleMessage(socket);

--- a/server/resources/socketHandler.js
+++ b/server/resources/socketHandler.js
@@ -47,18 +47,18 @@ exports.handleGetProblem = function(socket) {
   // use errorProblem when problem cannto be found
   var errorProblem = {title: 'error', prompt: 'error', template: 'error'};
 
-  // listening on 'getProblem' from client
-  socket.on('getProblem', function(problemID) {
+  // listening on 'problem' from client
+  socket.on('problem', function(problemID) {
     // grab the probelm from database
     dbProblem.findById(problemID)
       .then(function(problem) {
-        // emit 'sendProblem' to client with problem(type: object)
-        socket.emit('sendProblem', problem.dataValues);
+        // emit 'problem' to client with problem(type: object)
+        socket.emit('problem', problem.dataValues);
       })
       .catch(function(err) {
         console.error(err);
         // emit 'sendProblem' to client with problem(type: object)
-        socket.emit('sendProblem', errorProblem);
+        socket.emit('problem', errorProblem);
       });
 
   });
@@ -68,7 +68,7 @@ exports.handleGetProblem = function(socket) {
 // handle submit solution
 exports.handleSubmitSolution = function(socket) {
   // handle user's submitted solution
-  socket.on('submitSoln', function (userSolnObj) {
+  socket.on('codeSubmission', function (userSolnObj) {
     console.log('handlingSubmitSoln');
 
     var userSoln = userSolnObj.userSoln;
@@ -79,13 +79,13 @@ exports.handleSubmitSolution = function(socket) {
     syntaxChecker(userSoln, username, probID, function(success, error, errorMessage) {
       if(error) {
         // console.log(error);
-        socket.emit('solutionResult', errorMessage);
+        socket.emit('codeSubmission', errorMessage);
       }
       if(success) {
         // 2) check user's solution against mochaTests
         console.log('running mocha checker now')
         mochaChecker(userSoln, username, probID, function(result){
-          socket.emit('solutionResult', result);
+          socket.emit('codeSubmission', result);
           socket.broadcast.emit('compUpdate', username+': '+result);
         });
       }
@@ -93,18 +93,6 @@ exports.handleSubmitSolution = function(socket) {
     });
 
   });
-
-};
-
-// ================================================
-// live feed
-exports.handleLiveFee = function(socket) {
-
-};
-
-// ================================================
-// close
-exports.closeSocket = function(socket) {
 
 };
 


### PR DESCRIPTION
Configure all serverSocket listeners in the same place (roomEntry.jsx) when a user clicks on 'join' (this  is to avoid setting same listeners multiple times).

Please see revised socketDiagrame (Google Sheet has a link to the diagram under 'Link' tab)